### PR TITLE
feat: rework cache library to be backed by an array

### DIFF
--- a/src/main/kotlin/com/displee/cache/CacheLibrary.kt
+++ b/src/main/kotlin/com/displee/cache/CacheLibrary.kt
@@ -21,13 +21,13 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.RandomAccessFile
 import java.math.BigInteger
-import java.util.*
 
-open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = false, private val listener: ProgressListener? = null) {
+open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = false, private val listener: ProgressListener? = null): AutoCloseable {
 
     lateinit var mainFile: RandomAccessFile
 
-    private var indices: Array<Index?> = arrayOfNulls(0)
+    var indices: Array<Index?> = arrayOfNulls(0)
+        private set
     val compressors = Compressors()
     val whirlpool = Whirlpool()
     var index255: Index255? = null
@@ -60,7 +60,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         init()
     }
 
-    @Throws(IOException::class)
+    @Throws(FileNotFoundException::class, IOException::class)
     private fun load() {
         val main = File(path, "$CACHE_FILE_NAME.dat2")
         mainFile = if (main.exists()) {
@@ -82,7 +82,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         rs3 = indicesLength > 39
         for (i in 0 until indicesLength) {
             val file = File(path, "$CACHE_FILE_NAME.idx$i")
-            val progress = i / (indicesLength - 1.0)
+            val progress = if (indicesLength > 1) i / (indicesLength - 1.0) else 1.0
             if (!file.exists()) {
                 listener?.notify(progress, "Could not load index $i, missing idx file.")
                 continue
@@ -98,7 +98,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         }
     }
 
-    @Throws(IOException::class)
+    @Throws(FileNotFoundException::class, IOException::class)
     private fun load317() {
         val main = File(path, "$CACHE_FILE_NAME.dat")
         mainFile = if (main.exists()) {
@@ -115,7 +115,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         indices = arrayOfNulls(indexFiles.size)
         for (i in indexFiles.indices) {
             val file = File(path, "$CACHE_FILE_NAME.idx$i")
-            val progress = i / (indexFiles.size - 1.0)
+            val progress = if (indexFiles.size > 1) i / (indexFiles.size - 1.0) else 1.0
             if (!file.exists()) {
                 setIndex(i, null)
                 continue
@@ -131,17 +131,11 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         }
     }
 
-    private fun setIndex(index: Int, value: Index?) {
-        if (index >= indices.size) {
-            indices = indices.copyOf(index + 1)
-        }
-        indices[index] = value
-    }
-
+    @Synchronized
     @JvmOverloads
     fun createIndex(compressionType: CompressionType = CompressionType.GZIP, version: Int = 6, revision: Int = 0,
                     named: Boolean = false, whirlpool: Boolean = false, lengths: Boolean = false, checksums: Boolean = false,
-                    writeReferenceTable: Boolean = true, id: Int = indexCount + 1): Index {
+                    writeReferenceTable: Boolean = true, id: Int = (last()?.id ?: -1) + 1): Index {
         val raf = RandomAccessFile(File(path, "$CACHE_FILE_NAME.idx$id"), "rw")
         val index = (if (is317()) Index317(this, id, raf) else Index(this, id, raf)).also { setIndex(id, it) }
         if (!writeReferenceTable) {
@@ -168,72 +162,68 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         return index
     }
 
+    @Synchronized
     fun createIndex(index: Index, writeReferenceTable: Boolean = true): Index {
         return createIndex(index.compressionType, index.version, index.revision,
                 index.isNamed(), index.hasWhirlpool(), index.hasLengths(), index.hasChecksums(), writeReferenceTable, index.id)
     }
 
-    fun exists(id: Int): Boolean {
-        return indices.getOrNull(id) != null
-    }
-
-    fun index(id: Int): Index {
-        val index = indices.getOrNull(id)
-        return checkNotNull(index) { "Index $id doesn't exist. Please use the {@link exists(int) exists} function to verify whether an index exists." }
+    fun index(id: Int): Index? {
+        return indices.getOrNull(id)
     }
 
     @JvmOverloads
-    fun put(index: Int, archive: Int, file: Int, data: ByteArray, xtea: IntArray? = null): com.displee.cache.index.archive.file.File {
-        return index(index).add(archive, xtea = xtea).add(file, data)
+    fun put(index: Int, archive: Int, file: Int, data: ByteArray, xtea: IntArray? = null): com.displee.cache.index.archive.file.File? {
+        return index(index)?.add(archive, xtea = xtea)?.add(file, data)
     }
 
     @JvmOverloads
-    fun put(index: Int, archive: Int, data: ByteArray, xtea: IntArray? = null): Archive {
-        val currentArchive = index(index).add(archive, -1, xtea)
+    fun put(index: Int, archive: Int, data: ByteArray, xtea: IntArray? = null): Archive? {
+        val currentArchive = index(index)?.add(archive, -1, xtea) ?: return null
         currentArchive.add(0, data)
         return currentArchive
     }
 
     @JvmOverloads
-    fun put(index: Int, archive: Int, file: String, data: ByteArray, xtea: IntArray? = null): com.displee.cache.index.archive.file.File {
-        return index(index).add(archive, xtea = xtea).add(file, data)
+    fun put(index: Int, archive: Int, file: String, data: ByteArray, xtea: IntArray? = null): com.displee.cache.index.archive.file.File? {
+        return index(index)?.add(archive, xtea = xtea)?.add(file, data)
     }
 
     @JvmOverloads
-    fun put(index: Int, archive: String, data: ByteArray, xtea: IntArray? = null): Archive {
+    fun put(index: Int, archive: String, data: ByteArray, xtea: IntArray? = null): Archive? {
         return put(index, archive, 0, data, xtea)
     }
 
     @JvmOverloads
-    fun put(index: Int, archive: String, file: Int, data: ByteArray, xtea: IntArray? = null): Archive {
-        val currentArchive = index(index).add(archive, xtea = xtea)
+    fun put(index: Int, archive: String, file: Int, data: ByteArray, xtea: IntArray? = null): Archive? {
+        val currentArchive = index(index)?.add(archive, xtea = xtea) ?: return null
         currentArchive.add(file, data)
         return currentArchive
     }
 
     @JvmOverloads
-    fun put(index: Int, archive: String, file: String, data: ByteArray, xtea: IntArray? = null): com.displee.cache.index.archive.file.File {
-        return index(index).add(archive, xtea = xtea).add(file, data)
+    fun put(index: Int, archive: String, file: String, data: ByteArray, xtea: IntArray? = null): com.displee.cache.index.archive.file.File? {
+        return index(index)?.add(archive, xtea = xtea)?.add(file, data)
     }
 
     @JvmOverloads
     fun data(index: Int, archive: Int, file: Int = 0, xtea: IntArray? = null): ByteArray? {
-        return index(index).archive(archive, xtea)?.file(file)?.data
+        return index(index)?.archive(archive, xtea)?.file(file)?.data
     }
 
     @JvmOverloads
     fun data(index: Int, archive: Int, file: String, xtea: IntArray? = null): ByteArray? {
-        return index(index).archive(archive, xtea)?.file(file)?.data
+        return index(index)?.archive(archive, xtea)?.file(file)?.data
     }
 
     @JvmOverloads
     fun data(index: Int, archive: String, file: Int, xtea: IntArray? = null): ByteArray? {
-        return index(index).archive(archive, xtea)?.file(file)?.data
+        return index(index)?.archive(archive, xtea)?.file(file)?.data
     }
 
     @JvmOverloads
     fun data(index: Int, archive: String, file: String, xtea: IntArray? = null): ByteArray? {
-        return index(index).archive(archive, xtea)?.file(file)?.data
+        return index(index)?.archive(archive, xtea)?.file(file)?.data
     }
 
     @JvmOverloads
@@ -242,34 +232,32 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
     }
 
     fun remove(index: Int, archive: Int, file: Int): com.displee.cache.index.archive.file.File? {
-        return index(index).archive(archive)?.remove(file)
+        return index(index)?.archive(archive)?.remove(file)
     }
 
     fun remove(index: Int, archive: Int, file: String): com.displee.cache.index.archive.file.File? {
-        return index(index).archive(archive)?.remove(file)
+        return index(index)?.archive(archive)?.remove(file)
     }
 
     fun remove(index: Int, archive: String, file: String): com.displee.cache.index.archive.file.File? {
-        return index(index).archive(archive)?.remove(file)
+        return index(index)?.archive(archive)?.remove(file)
     }
 
     fun remove(index: Int, archive: String, file: Int): com.displee.cache.index.archive.file.File? {
-        return index(index).archive(archive)?.remove(file)
+        return index(index)?.archive(archive)?.remove(file)
     }
 
     fun remove(index: Int, archive: Int): Archive? {
-        return index(index).remove(archive)
+        return index(index)?.remove(archive)
     }
 
     fun remove(index: Int, archive: String): Archive? {
-        return index(index).remove(archive)
+        return index(index)?.remove(archive)
     }
 
+    @Synchronized
     fun update() {
-        for (index in indices) {
-            if (index == null) {
-                continue
-            }
+        for (index in validIndices()) {
             if (index.flaggedArchives().isEmpty() && !index.flagged()) {
                 continue
             }
@@ -277,13 +265,14 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         }
     }
 
-    @Throws(RuntimeException::class)
+    @Synchronized
+    @Throws(UnsupportedOperationException::class, RuntimeException::class)
     fun deleteLastIndex() {
         if (is317()) {
             throw UnsupportedOperationException("317 not supported to remove indices yet.")
         }
-        val id = indexCount
-        val index = indices.getOrNull(id) ?: return
+        val index = last() ?: return
+        val id = index.id
         index.close()
         val file = File(path, "$CACHE_FILE_NAME.idx$id")
         if (!file.exists() || !file.delete()) {
@@ -294,13 +283,17 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
     }
 
     @JvmOverloads
+    @Throws(IllegalArgumentException::class)
     fun generateUkeys(writeWhirlpool: Boolean = true, exponent: BigInteger? = null, modulus: BigInteger? = null): ByteArray {
+        if ((exponent == null) != (modulus == null)) {
+            throw IllegalArgumentException("Both exponent and modulus must be provided together")
+        }
         val buffer = OutputBuffer(6 + indexCount * 72)
         if (writeWhirlpool) {
             buffer.writeByte(indexCount)
         }
         val emptyWhirlpool = ByteArray(WHIRLPOOL_SIZE)
-        for (index in indices()) {
+        for (index in validIndices()) {
             buffer.writeInt(index.crc).writeInt(index.revision)
             if (writeWhirlpool) {
                 buffer.writeBytes(index.whirlpool ?: emptyWhirlpool)
@@ -321,17 +314,14 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
     fun rebuild(directory: File) {
         File(directory.path).mkdirs()
         if (is317()) {
-            File(directory.path, "$CACHE_FILE_NAME.dat").createNewFile()
+            File(directory, "$CACHE_FILE_NAME.dat").apply { if (!exists()) createNewFile() }
         } else {
-            File(directory.path, "$CACHE_FILE_NAME.idx255").createNewFile()
-            File(directory.path, "$CACHE_FILE_NAME.dat2").createNewFile()
+            File(directory, "$CACHE_FILE_NAME.idx255").apply { if (!exists()) createNewFile() }
+            File(directory, "$CACHE_FILE_NAME.dat2").apply { if (!exists()) createNewFile() }
         }
         val indicesSize = indices.count { it != null }
         val newLibrary = CacheLibrary(directory.path)
-        for (index in indices) {
-            if (index == null) {
-                continue
-            }
+        for (index in validIndices()) {
             val id = index.id
             print("\rBuilding index $id/$indicesSize...")
             val archiveSector = index255?.readArchiveSector(id)
@@ -353,22 +343,22 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
     }
 
     fun fixCrcs(update: Boolean) {
-        for(index in indices) {
-            if (index == null || index.archiveIds().isEmpty()) {
+        for (index in validIndices()) {
+            if (index.archiveIds().isEmpty()) {
                 continue
             }
             index.fixCRCs(update)
         }
     }
 
-    fun close() {
+    override fun close() {
         if (closed) {
             return
         }
-        mainFile.close()
-        index255?.close()
-        for (index in indices) {
-            index?.close()
+        runCatching { mainFile.close() }
+        runCatching { index255?.close() }
+        indices.forEach {
+            runCatching { it?.close() }
         }
         closed = true
     }
@@ -386,7 +376,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
     }
 
     fun isOSRS(): Boolean {
-        val index = index(2)
+        val index = index(2) ?: return false
         return index.revision >= 300 && indexCount <= 25
     }
 
@@ -394,8 +384,15 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
         return rs3
     }
 
-    fun indices(): Array<Index> {
+    fun validIndices(): Array<Index> {
         return indices.filterNotNull().toTypedArray()
+    }
+
+    private fun setIndex(index: Int, value: Index?) {
+        if (index >= indices.size) {
+            indices = indices.copyOf(index + 1)
+        }
+        indices[index] = value
     }
 
     companion object {

--- a/src/main/kotlin/com/displee/cache/CacheLibrary.kt
+++ b/src/main/kotlin/com/displee/cache/CacheLibrary.kt
@@ -387,7 +387,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
 
     fun isOSRS(): Boolean {
         val index = index(2)
-        return index.revision >= 300 && indexCount <= 23
+        return index.revision >= 300 && indexCount <= 24
     }
 
     fun isRS3(): Boolean {

--- a/src/main/kotlin/com/displee/cache/CacheLibrary.kt
+++ b/src/main/kotlin/com/displee/cache/CacheLibrary.kt
@@ -387,7 +387,7 @@ open class CacheLibrary(val path: String, val clearDataAfterUpdate: Boolean = fa
 
     fun isOSRS(): Boolean {
         val index = index(2)
-        return index.revision >= 300 && indexCount <= 24
+        return index.revision >= 300 && indexCount <= 25
     }
 
     fun isRS3(): Boolean {


### PR DESCRIPTION
array works such that the index is set to the position in the array and also that it will expand when indexes are added. When delete last index is called it will shrink. This is an alternative to https://github.com/Displee/rs-cache-library/pull/70